### PR TITLE
escape character showing in string

### DIFF
--- a/LexAnalyzer/PA2/cool.flex
+++ b/LexAnalyzer/PA2/cool.flex
@@ -232,6 +232,8 @@ TYPEID          [A-Z][A-Za-z0-9_]*
     BEGIN(STRING_ERROR);
     return ERROR;   
   }
+
+  string_buf[buffer_index-1] = ' ';
 }
 
 <STRING_ERROR>. ; /* Do nothing while \n is not found */


### PR DESCRIPTION
When using \ character before breaking the line, the character '\' was considered as part of the string